### PR TITLE
docs: correct typo in installation tabs from "manuel" to "manual"

### DIFF
--- a/app/docs/components/3d-tilt-effect/page.mdx
+++ b/app/docs/components/3d-tilt-effect/page.mdx
@@ -19,9 +19,9 @@ The 3D Tilt Effect is an interactive visual technique that makes cards or images
 
 ## Installation
 
-<Tabs defaultValue="manuel" className="w-[400px]">
+<Tabs defaultValue="manual" className="w-[400px]">
     <TabsList>
-        <TabsTrigger value="manuel">Manuel</TabsTrigger>
+        <TabsTrigger value="manual">Manual</TabsTrigger>
         <TabsTrigger disabled value="cli">CLI (Coming Soon)</TabsTrigger>
     </TabsList>
 </Tabs>

--- a/app/docs/components/background-meteor-shower-animation/page.mdx
+++ b/app/docs/components/background-meteor-shower-animation/page.mdx
@@ -17,9 +17,9 @@ The Meteor Shower Animation background adds a stunning layer of motion and elega
 
 ## Installation
 
-<Tabs defaultValue="manuel" className="w-[400px]">
+<Tabs defaultValue="manual" className="w-[400px]">
     <TabsList>
-        <TabsTrigger value="manuel">Manuel</TabsTrigger>
+        <TabsTrigger value="manual">Manual</TabsTrigger>
         <TabsTrigger disabled value="cli">CLI (Coming Soon)</TabsTrigger>
     </TabsList>
 </Tabs>

--- a/app/docs/components/background-snowfall-animation/page.mdx
+++ b/app/docs/components/background-snowfall-animation/page.mdx
@@ -17,9 +17,9 @@ The Snowfall Animation Background offers a winter-inspired animated backdrop tha
 
 ## Installation
 
-<Tabs defaultValue="manuel" className="w-[400px]">
+<Tabs defaultValue="manual" className="w-[400px]">
     <TabsList>
-        <TabsTrigger value="manuel">Manuel</TabsTrigger>
+        <TabsTrigger value="manual">Manual</TabsTrigger>
         <TabsTrigger disabled value="cli">CLI (Coming Soon)</TabsTrigger>
     </TabsList>
 </Tabs>

--- a/app/docs/components/button/page.mdx
+++ b/app/docs/components/button/page.mdx
@@ -19,9 +19,9 @@ Button component for redirects and forms.
 
 ## Installation
 
-<Tabs defaultValue="manuel" className="w-[400px]">
+<Tabs defaultValue="manual" className="w-[400px]">
     <TabsList>
-        <TabsTrigger value="manuel">Manuel</TabsTrigger>
+        <TabsTrigger value="manual">Manual</TabsTrigger>
         <TabsTrigger disabled value="cli">CLI (Coming Soon)</TabsTrigger>
     </TabsList>
 </Tabs>

--- a/app/docs/components/count-animation/page.mdx
+++ b/app/docs/components/count-animation/page.mdx
@@ -32,9 +32,9 @@ The count animation component is designed to create a captivating user experienc
 
 ## Installation
 
-<Tabs defaultValue="manuel" className="w-[400px]">
+<Tabs defaultValue="manual" className="w-[400px]">
     <TabsList>
-        <TabsTrigger value="manuel">Manuel</TabsTrigger>
+        <TabsTrigger value="manual">Manual</TabsTrigger>
         <TabsTrigger disabled value="cli">CLI (Coming Soon)</TabsTrigger>
     </TabsList>
 </Tabs>

--- a/app/docs/components/fireworks-background/page.mdx
+++ b/app/docs/components/fireworks-background/page.mdx
@@ -18,9 +18,9 @@ Fireworks Background is a visually striking animation component that simulates c
 
 ## Installation
 
-<Tabs defaultValue="manuel" className="w-[400px]">
+<Tabs defaultValue="manual" className="w-[400px]">
     <TabsList>
-        <TabsTrigger value="manuel">Manuel</TabsTrigger>
+        <TabsTrigger value="manual">Manual</TabsTrigger>
         <TabsTrigger disabled value="cli">CLI (Coming Soon)</TabsTrigger>
     </TabsList>
 </Tabs>

--- a/app/docs/components/floating-button/page.mdx
+++ b/app/docs/components/floating-button/page.mdx
@@ -19,9 +19,9 @@ A floating button is a common UI component used in user interfaces. It typically
 
 ## Installation
 
-<Tabs defaultValue="manuel" className="w-[400px]">
+<Tabs defaultValue="manual" className="w-[400px]">
     <TabsList>
-        <TabsTrigger value="manuel">Manuel</TabsTrigger>
+        <TabsTrigger value="manual">Manual</TabsTrigger>
         <TabsTrigger disabled value="cli">CLI (Coming Soon)</TabsTrigger>
     </TabsList>
 </Tabs>

--- a/app/docs/components/floating-paths-background/page.mdx
+++ b/app/docs/components/floating-paths-background/page.mdx
@@ -18,9 +18,9 @@ Floating Paths Background is a decorative background animation component that cr
 
 ## Installation
 
-<Tabs defaultValue="manuel" className="w-[400px]">
+<Tabs defaultValue="manual" className="w-[400px]">
     <TabsList>
-        <TabsTrigger value="manuel">Manuel</TabsTrigger>
+        <TabsTrigger value="manual">Manual</TabsTrigger>
         <TabsTrigger disabled value="cli">CLI (Coming Soon)</TabsTrigger>
     </TabsList>
 </Tabs>

--- a/app/docs/components/fluid-particles-background/page.mdx
+++ b/app/docs/components/fluid-particles-background/page.mdx
@@ -17,9 +17,9 @@ The Fluid Particles Background is an interactive and dynamic background that uti
 
 ## Installation
 
-<Tabs defaultValue="manuel" className="w-[400px]">
+<Tabs defaultValue="manual" className="w-[400px]">
     <TabsList>
-        <TabsTrigger value="manuel">Manuel</TabsTrigger>
+        <TabsTrigger value="manual">Manual</TabsTrigger>
         <TabsTrigger disabled value="cli">CLI (Coming Soon)</TabsTrigger>
     </TabsList>
 </Tabs>

--- a/app/docs/components/geometric-background/page.mdx
+++ b/app/docs/components/geometric-background/page.mdx
@@ -17,9 +17,9 @@ The Geometric Background component features a modern and sophisticated design, i
 
 ## Installation
 
-<Tabs defaultValue="manuel" className="w-[400px]">
+<Tabs defaultValue="manual" className="w-[400px]">
     <TabsList>
-        <TabsTrigger value="manuel">Manuel</TabsTrigger>
+        <TabsTrigger value="manual">Manual</TabsTrigger>
         <TabsTrigger disabled value="cli">CLI (Coming Soon)</TabsTrigger>
     </TabsList>
 </Tabs>

--- a/app/docs/components/magnetic-button/page.mdx
+++ b/app/docs/components/magnetic-button/page.mdx
@@ -19,9 +19,9 @@ A Magnetic Button is a UI component designed to enhance user interaction. When a
 
 ## Installation
 
-<Tabs defaultValue="manuel" className="w-[400px]">
+<Tabs defaultValue="manual" className="w-[400px]">
     <TabsList>
-        <TabsTrigger value="manuel">Manuel</TabsTrigger>
+        <TabsTrigger value="manual">Manual</TabsTrigger>
         <TabsTrigger disabled value="cli">CLI (Coming Soon)</TabsTrigger>
     </TabsList>
 </Tabs>

--- a/app/docs/components/marquee-effect/page.mdx
+++ b/app/docs/components/marquee-effect/page.mdx
@@ -21,9 +21,9 @@ The marquee component is designed to create a dynamic user experience by continu
 
 ## Installation
 
-<Tabs defaultValue="manuel" className="w-[400px]">
+<Tabs defaultValue="manual" className="w-[400px]">
     <TabsList>
-        <TabsTrigger value="manuel">Manuel</TabsTrigger>
+        <TabsTrigger value="manual">Manual</TabsTrigger>
         <TabsTrigger disabled value="cli">CLI (Coming Soon)</TabsTrigger>
     </TabsList>
 </Tabs>

--- a/app/docs/components/scroll-progress-bar/page.mdx
+++ b/app/docs/components/scroll-progress-bar/page.mdx
@@ -29,9 +29,9 @@ The Scroll Progress Bar component enhances user experience by providing a visual
 
 ## Installation
 
-<Tabs defaultValue="manuel" className="w-[400px]">
+<Tabs defaultValue="manual" className="w-[400px]">
     <TabsList>
-        <TabsTrigger value="manuel">Manuel</TabsTrigger>
+        <TabsTrigger value="manual">Manual</TabsTrigger>
         <TabsTrigger disabled value="cli">CLI (Coming Soon)</TabsTrigger>
     </TabsList>
 </Tabs>

--- a/app/docs/components/stars-background/page.mdx
+++ b/app/docs/components/stars-background/page.mdx
@@ -18,9 +18,9 @@ A minimalist animated stars background component for React. It creates a smooth 
 
 ## Installation
 
-<Tabs defaultValue="manuel" className="w-[400px]">
+<Tabs defaultValue="manual" className="w-[400px]">
     <TabsList>
-        <TabsTrigger value="manuel">Manuel</TabsTrigger>
+        <TabsTrigger value="manual">Manual</TabsTrigger>
         <TabsTrigger disabled value="cli">CLI (Coming Soon)</TabsTrigger>
     </TabsList>
 </Tabs>

--- a/app/docs/components/text-gradient-scroll/page.mdx
+++ b/app/docs/components/text-gradient-scroll/page.mdx
@@ -19,9 +19,9 @@ The text gradient scroll component is designed to enhance user interaction by pr
 
 ## Installation
 
-<Tabs defaultValue="manuel" className="w-[400px]">
+<Tabs defaultValue="manual" className="w-[400px]">
     <TabsList>
-        <TabsTrigger value="manuel">Manuel</TabsTrigger>
+        <TabsTrigger value="manual">Manual</TabsTrigger>
         <TabsTrigger disabled value="cli">CLI (Coming Soon)</TabsTrigger>
     </TabsList>
 </Tabs>

--- a/app/docs/components/wavy-background/page.mdx
+++ b/app/docs/components/wavy-background/page.mdx
@@ -17,9 +17,9 @@ The Wavy Background component adds a dynamic, flowing wave effect to the backgro
 
 ## Installation
 
-<Tabs defaultValue="manuel" className="w-[400px]">
+<Tabs defaultValue="manual" className="w-[400px]">
     <TabsList>
-        <TabsTrigger value="manuel">Manuel</TabsTrigger>
+        <TabsTrigger value="manual">Manual</TabsTrigger>
         <TabsTrigger disabled value="cli">CLI (Coming Soon)</TabsTrigger>
     </TabsList>
 </Tabs>


### PR DESCRIPTION
The term "manuel" was consistently misspelled across multiple documentation files. This commit fixes the typo by replacing it with the correct spelling "manual" to ensure clarity and accuracy in the documentation.

Really cool library, not sure if the spelling "manuel" was done purposefully since it's on every single component, but in case it's not pr'd it.

Can't wait to see what you guys add in the future